### PR TITLE
don't tolowercase body/query fields

### DIFF
--- a/lib/passport-token/strategy.js
+++ b/lib/passport-token/strategy.js
@@ -51,9 +51,9 @@ function Strategy(options, verify) {
   
   this._tokenHeader    = options.tokenHeader ? options.tokenHeader.toLowerCase()    : 'x-token';
   
-  this._tokenField    = options.tokenField ? options.tokenField.toLowerCase()    : 'token';
+  this._tokenField    = options.tokenField ? options.tokenField    : 'token';
 
-  this._tokenQuery    = options.tokenQuery ? options.tokenQuery.toLowerCase()    : this._tokenField;
+  this._tokenQuery    = options.tokenQuery ? options.tokenQuery    : this._tokenField;
   
   passport.Strategy.call(this);
   this.name = 'token';


### PR DESCRIPTION
While headers are case insensitive, body and query parameters aren't. In my scenario, in the body the API is receiving, the access token is provided as `accessToken`.